### PR TITLE
Print, but don't fail on deprecation notice

### DIFF
--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -7,8 +7,9 @@ module PuppetSyntax
   @exclude_paths = []
   @future_parser = false
   @hieradata_paths = ["**/data/**/*.yaml", "hieradata/**/*.yaml", "hiera*.yaml"]
+  @fail_on_warnings = true
 
   class << self
-    attr_accessor :exclude_paths, :future_parser, :hieradata_paths
+    attr_accessor :exclude_paths, :future_parser, :hieradata_paths, :fail_on_warnings
   end
 end

--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -7,9 +7,9 @@ module PuppetSyntax
   @exclude_paths = []
   @future_parser = false
   @hieradata_paths = ["**/data/**/*.yaml", "hieradata/**/*.yaml", "hiera*.yaml"]
-  @fail_on_warnings = true
+  @fail_on_deprecation_notices = true
 
   class << self
-    attr_accessor :exclude_paths, :future_parser, :hieradata_paths, :fail_on_warnings
+    attr_accessor :exclude_paths, :future_parser, :hieradata_paths, :fail_on_deprecation_notices
   end
 end

--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -36,12 +36,12 @@ module PuppetSyntax
         e =~ /^You cannot collect( exported resources)? without storeconfigs being set/
       }
 
-      warnings = output.select { |e|
+      deprecations = output.select { |e|
         e =~ /^Deprecation notice:|is deprecated/
       }
 
-      # Errors exist if there is any output that isn't a warning.
-      has_errors = (output != warnings)
+      # Errors exist if there is any output that isn't a deprecation notice.
+      has_errors = (output != deprecations)
 
       return output, has_errors
     end

--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -41,7 +41,7 @@ module PuppetSyntax
       }
 
       # Errors exist if there is any output that isn't a warning.
-      has_errors = (not output == warnings)
+      has_errors = (output != warnings)
 
       return output, has_errors
     end

--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -5,7 +5,7 @@ module PuppetSyntax
       require 'puppet'
       require 'puppet/face'
 
-      errors = []
+      output = []
 
       # FIXME: We shouldn't need to do this. puppet/face should. See:
       # - http://projects.puppetlabs.com/issues/15529
@@ -15,7 +15,7 @@ module PuppetSyntax
       end
 
       # Catch syntax warnings.
-      Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(errors))
+      Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(output))
       Puppet::Util::Log.level = :warning
 
       filelist.each do |puppet_file|
@@ -24,19 +24,26 @@ module PuppetSyntax
         rescue SystemExit
           # Disregard exit(1) from face.
         rescue => error
-          errors << error
+          output << error
         end
       end
 
       Puppet::Util::Log.close_all
-      errors.map! { |e| e.to_s }
+      output.map! { |e| e.to_s }
 
       # Exported resources will raise warnings when outside a puppetmaster.
-      errors.reject! { |e|
+      output.reject! { |e|
         e =~ /^You cannot collect( exported resources)? without storeconfigs being set/
       }
 
-      errors
+      warnings = output.select { |e|
+        e =~ /^Deprecation notice:|is deprecated/
+      }
+
+      # Errors exist if there is any output that isn't a warning.
+      has_errors = (not output == warnings)
+
+      return output, has_errors
     end
 
     private

--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -36,8 +36,9 @@ to puppetlabs_spec_helper >= 0.8.0 which now uses puppet-syntax.
           files = files.exclude(*PuppetSyntax.exclude_paths)
 
           c = PuppetSyntax::Manifests.new
-          errors = c.check(files)
-          fail errors.join("\n") unless errors.empty?
+          output, has_errors = c.check(files)
+          print "#{output.join("\n")}\n" unless output.empty?
+          fail if has_errors || ( output.any? && PuppetSyntax.fail_on_warnings )
         end
 
         desc 'Syntax check Puppet templates'

--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -38,7 +38,7 @@ to puppetlabs_spec_helper >= 0.8.0 which now uses puppet-syntax.
           c = PuppetSyntax::Manifests.new
           output, has_errors = c.check(files)
           print "#{output.join("\n")}\n" unless output.empty?
-          fail if has_errors || ( output.any? && PuppetSyntax.fail_on_warnings )
+          fail if has_errors || ( output.any? && PuppetSyntax.fail_on_deprecation_notices )
         end
 
         desc 'Syntax check Puppet templates'

--- a/spec/fixtures/test_module/manifests/deprecation_notice.pp
+++ b/spec/fixtures/test_module/manifests/deprecation_notice.pp
@@ -1,0 +1,6 @@
+node test inherits default {
+  import 'pass.pp'
+  notify { 'this should give a deprecation notice':
+    message => 'inheritance is gone in the future parser',
+  }
+}

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -134,7 +134,7 @@ describe PuppetSyntax::Manifests do
           end
         end
       else
-        context 'Puppet <= 3.2' do
+        context 'Puppet < 3.2' do
           it 'should return an error that the parser option is not supported' do
             files = fixture_manifests(['future_syntax.pp'])
             output, has_errors = subject.check(files)

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -123,7 +123,7 @@ describe PuppetSyntax::Manifests do
         context 'Puppet >= 3.7' do
           # Certain elements of the future parser weren't added until 3.7
           if Puppet::Util::Package.versioncmp(Puppet.version, '3.7') >= 0
-            it 'should fail on what were deprecation notices in the < 4.0 parser' do
+            it 'should fail on what were deprecation notices in the non-future parser' do
               files = fixture_manifests('deprecation_notice.pp')
               output, has_errors = subject.check(files)
 

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -78,6 +78,17 @@ describe PuppetSyntax::Manifests do
           expect(output[1]).to match(/Deprecation notice:/)
         end
       end
+    elsif Puppet::Util::Package.versioncmp(Puppet.version, '3.5') >= 0
+      context 'on puppet 3.5 and 3.6' do
+        it 'should return deprecation notices as warnings' do
+          files = fixture_manifests('deprecation_notice.pp')
+          output, has_errors = subject.check(files)
+
+          expect(has_errors).to eq(false)
+          expect(output.size).to eq(1)
+          expect(output[0]).to match(/The use of 'import' is deprecated/)
+        end
+      end
     elsif Puppet::Util::Package.versioncmp(Puppet.version, '3.5') < 0
       context 'on puppet < 3.5' do
         it 'should not print deprecation notices' do

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -76,8 +76,8 @@ describe PuppetSyntax::Manifests do
           expect(output[1]).to match(/Deprecation notice:/)
         end
       end
-    else
-      context 'on puppet < 3.7' do
+    elsif Puppet::Util::Package.versioncmp(Puppet.version, '3.5') < 0
+      context 'on puppet < 3.5' do
         it 'should not print deprecation notices' do
           files = fixture_manifests('deprecation_notice.pp')
           output, has_errors = subject.check(files)
@@ -118,7 +118,7 @@ describe PuppetSyntax::Manifests do
             expect(has_errors).to eq(false)
           end
         end
-        context 'Puppet >= 3.7 and < 4.0' do
+        context 'Puppet >= 3.7' do
           # Certain elements of the future parser weren't added until 3.7
           if Puppet::Util::Package.versioncmp(Puppet.version, '3.7') >= 0
             it 'should fail on what were deprecation notices in the < 4.0 parser' do

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -10,50 +10,83 @@ describe PuppetSyntax::Manifests do
 
   it 'should return nothing from a valid file' do
     files = fixture_manifests('pass.pp')
-    res = subject.check(files)
+    output, has_errors = subject.check(files)
 
-    expect(res).to eq([])
+    expect(output).to eq([])
+    expect(has_errors).to eq(false)
   end
 
   it 'should return an error from an invalid file' do
     files = fixture_manifests('fail_error.pp')
-    res = subject.check(files)
+    output, has_errors = subject.check(files)
 
-    expect(res.size).to eq(1)
-    expect(res[0]).to match(/Syntax error at .*:3$/)
+    expect(output.size).to eq(1)
+    expect(output[0]).to match(/Syntax error at .*:3$/)
+    expect(has_errors).to eq(true)
   end
 
   it 'should return a warning from an invalid file' do
     files = fixture_manifests('fail_warning.pp')
-    res = subject.check(files)
+    output, has_errors = subject.check(files)
 
-    expect(res.size).to eq(2)
-    expect(res[0]).to match(/Unrecognised escape sequence '\\\[' .* at line 3$/)
-    expect(res[1]).to match(/Unrecognised escape sequence '\\\]' .* at line 3$/)
+    expect(output.size).to eq(2)
+    expect(output[0]).to match(/Unrecognised escape sequence '\\\[' .* at line 3$/)
+    expect(output[1]).to match(/Unrecognised escape sequence '\\\]' .* at line 3$/)
+    expect(has_errors).to eq(true)
   end
 
   it 'should ignore warnings about storeconfigs' do
     files = fixture_manifests('pass_storeconfigs.pp')
-    res = subject.check(files)
+    output, has_errors = subject.check(files)
 
-    expect(res).to eq([])
+    expect(output).to eq([])
+    expect(has_errors).to eq(false)
+
   end
 
   it 'should read more than one valid file' do
     files = fixture_manifests(['pass.pp', 'pass_storeconfigs.pp'])
-    res = subject.check(files)
+    output, has_errors = subject.check(files)
 
-    expect(res).to eq([])
+    expect(output).to eq([])
+    expect(has_errors).to eq(false)
   end
 
   it 'should continue after finding an error in the first file' do
     files = fixture_manifests(['fail_error.pp', 'fail_warning.pp'])
-    res = subject.check(files)
+    output, has_errors = subject.check(files)
 
-    expect(res.size).to eq(3)
-    expect(res[0]).to match(/Syntax error at '\}' .*:3$/)
-    expect(res[1]).to match(/Unrecognised escape sequence '\\\[' .* at line 3$/)
-    expect(res[2]).to match(/Unrecognised escape sequence '\\\]' .* at line 3$/)
+    expect(output.size).to eq(3)
+    expect(output[0]).to match(/Syntax error at '\}' .*:3$/)
+    expect(output[1]).to match(/Unrecognised escape sequence '\\\[' .* at line 3$/)
+    expect(output[2]).to match(/Unrecognised escape sequence '\\\]' .* at line 3$/)
+    expect(has_errors).to eq(true)
+  end
+
+  describe 'deprecation notices' do
+    if Puppet::Util::Package.versioncmp(Puppet.version, '3.7') >= 0 and Puppet::Util::Package.versioncmp(Puppet.version, '4.0') < 0
+      context 'on puppet >= 3.7 and < 4.0' do
+        it 'should return deprecation notices as warnings' do
+          files = fixture_manifests('deprecation_notice.pp')
+          output, has_errors = subject.check(files)
+
+          expect(has_errors).to eq(false)
+          expect(output.size).to eq(2)
+          expect(output[0]).to match(/The use of 'import' is deprecated/)
+          expect(output[1]).to match(/Deprecation notice:/)
+        end
+      end
+    else
+      context 'on puppet < 3.7' do
+        it 'should not print deprecation notices' do
+          files = fixture_manifests('deprecation_notice.pp')
+          output, has_errors = subject.check(files)
+
+          expect(output).to eq([])
+          expect(has_errors).to eq(false)
+        end
+      end
+    end
   end
 
   describe 'future_parser' do
@@ -62,10 +95,11 @@ describe PuppetSyntax::Manifests do
         expect(PuppetSyntax.future_parser).to eq(false)
 
         files = fixture_manifests(['future_syntax.pp'])
-        res = subject.check(files)
+        output, has_errors = subject.check(files)
 
-        expect(res.size).to eq(1)
-        expect(res[0]).to match(/Syntax error at '='; expected '\}' .*:2$/)
+        expect(output.size).to eq(1)
+        expect(output[0]).to match(/Syntax error at '='; expected '\}' .*:2$/)
+        expect(has_errors).to eq(true)
       end
     end
 
@@ -78,19 +112,34 @@ describe PuppetSyntax::Manifests do
         context 'Puppet >= 3.2' do
           it 'should pass with future option set to true on future manifest' do
             files = fixture_manifests(['future_syntax.pp'])
-            res = subject.check(files)
+            output, has_errors = subject.check(files)
 
-            expect(res.size).to eq(0)
+            expect(output).to eq([])
+            expect(has_errors).to eq(false)
+          end
+        end
+        context 'Puppet >= 3.7 and < 4.0' do
+          # Certain elements of the future parser weren't added until 3.7
+          if Puppet::Util::Package.versioncmp(Puppet.version, '3.7') >= 0
+            it 'should fail on what were deprecation notices in the < 4.0 parser' do
+              files = fixture_manifests('deprecation_notice.pp')
+              output, has_errors = subject.check(files)
+
+              expect(output.size).to eq(1)
+              expect(output[0]).to match(/Node inheritance is not supported/)
+              expect(has_errors).to eq(true)
+            end
           end
         end
       else
         context 'Puppet <= 3.2' do
           it 'should return an error that the parser option is not supported' do
             files = fixture_manifests(['future_syntax.pp'])
-            res = subject.check(files)
+            output, has_errors = subject.check(files)
 
-            expect(res.size).to eq(1)
-            expect(res[0]).to match("Attempt to assign a value to unknown configuration parameter :parser")
+            expect(output.size).to eq(1)
+            expect(output[0]).to match("Attempt to assign a value to unknown configuration parameter :parser")
+            expect(has_errors).to eq(true)
           end
         end
       end

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -64,8 +64,10 @@ describe PuppetSyntax::Manifests do
   end
 
   describe 'deprecation notices' do
-    if Puppet::Util::Package.versioncmp(Puppet.version, '3.7') >= 0 and Puppet::Util::Package.versioncmp(Puppet.version, '4.0') < 0
-      context 'on puppet >= 3.7 and < 4.0' do
+    # These tests should fail in Puppet 4, but we need to wait for the release
+    # before we'll know exactly how to test it.
+    if Puppet::Util::Package.versioncmp(Puppet.version, '3.7') >= 0
+      context 'on puppet >= 3.7' do
         it 'should return deprecation notices as warnings' do
           files = fixture_manifests('deprecation_notice.pp')
           output, has_errors = subject.check(files)

--- a/spec/puppet-syntax_spec.rb
+++ b/spec/puppet-syntax_spec.rb
@@ -24,4 +24,9 @@ describe PuppetSyntax do
     expect(PuppetSyntax.future_parser).to eq(true)
   end
 
+  it 'should support a fail_on_warnings setting' do
+    PuppetSyntax.fail_on_warnings = false
+    expect(PuppetSyntax.fail_on_warnings).to eq(false)
+  end
+
 end

--- a/spec/puppet-syntax_spec.rb
+++ b/spec/puppet-syntax_spec.rb
@@ -24,9 +24,9 @@ describe PuppetSyntax do
     expect(PuppetSyntax.future_parser).to eq(true)
   end
 
-  it 'should support a fail_on_warnings setting' do
-    PuppetSyntax.fail_on_warnings = false
-    expect(PuppetSyntax.fail_on_warnings).to eq(false)
+  it 'should support a fail_on_deprecation_notices setting' do
+    PuppetSyntax.fail_on_deprecation_notices = false
+    expect(PuppetSyntax.fail_on_deprecation_notices).to eq(false)
   end
 
 end


### PR DESCRIPTION
A simple change so that deprecation notices are printed, but don't cause test failures. A possible fix for issue #27.