### PR TITLE
Let Array#<< modify default configuration values

### DIFF
--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -4,19 +4,11 @@ require "puppet-syntax/templates"
 require "puppet-syntax/hiera"
 
 module PuppetSyntax
+  @exclude_paths = []
+  @future_parser = false
+  @hieradata_paths = ["**/data/**/*.yaml", "hieradata/**/*.yaml", "hiera*.yaml"]
+
   class << self
     attr_accessor :exclude_paths, :future_parser, :hieradata_paths
-
-    def exclude_paths
-      @exclude_paths || []
-    end
-
-    def future_parser
-      @future_parser || false
-    end
-
-    def hieradata_paths
-      @hieradata_paths || ["**/data/**/*.yaml", "hieradata/**/*.yaml", "hiera*.yaml"]
-    end
   end
 end

--- a/spec/puppet-syntax_spec.rb
+++ b/spec/puppet-syntax_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe PuppetSyntax do
+  after do
+    PuppetSyntax.exclude_paths = []
+  end
+
   it 'should default exclude_paths to empty array' do
     expect(PuppetSyntax.exclude_paths).to be_empty
   end
@@ -8,6 +12,11 @@ describe PuppetSyntax do
   it 'should support setting exclude_paths' do
     PuppetSyntax.exclude_paths = ["foo", "bar/baz"]
     expect(PuppetSyntax.exclude_paths).to eq(["foo", "bar/baz"])
+  end
+
+  it 'should support appending exclude_paths' do
+    PuppetSyntax.exclude_paths << "foo"
+    expect(PuppetSyntax.exclude_paths).to eq(["foo"])
   end
 
   it 'should support future parser setting' do


### PR DESCRIPTION
Previously, config reader methods would return a new array for the default
value of paths, so if a user did:

    PuppetSyntax.exclude_paths << "spec/fixtures/**/*.pp"

e.g. in puppetlabs_spec_helper, then the new path would get appended to the
new array and not change the actual configuration.  Now the array is set as
the default first, so in-place modifications of arrays are preserved.

---

The puppetlabs_spec_helper code assumes this works (as it does in puppet-lint and other gems): https://github.com/puppetlabs/puppetlabs_spec_helper/blob/0.8.2/lib/puppetlabs_spec_helper/rake_tasks.rb#L208.  Similarly if you try and append more paths in your own Rakefile, they're silently ignored.