### PR TITLE
Remove travis testing of ruby 1.8.7 and puppet 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ script: bundle exec rake
 rvm:
   - 1.9.3
 env:
-  - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.0.0"
   - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: ruby
 script: bundle exec rake
 rvm:
-  - 1.8.7
   - 1.9.3
 env:
   - PUPPET_VERSION="~> 2.7.0"


### PR DESCRIPTION
We have decided to no longer support these in our open source stuff.