### PR TITLE
Release version 2.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2015-02-25 Release 2.0.0
+- Removed support for Puppet version 2.7.x
+- New option, fail_on_deprecation_notices, which defaults to true (compatible
+with previous behaviour); thanks @pcfens
+- PuppetSyntax::Manifests#check now has two return arguments
+
 2015-01-08 Release 1.4.1
 - Support appending to config arrays, thanks @domcleal
 

--- a/lib/puppet-syntax/version.rb
+++ b/lib/puppet-syntax/version.rb
@@ -1,3 +1,3 @@
 module PuppetSyntax
-  VERSION = "1.4.1"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
The major version bump is due to the API change in
PuppetSyntax::Manifests#check.

I'm not 100% sure that the major version bump is required, so would appreciate any feedback.