### PR TITLE
Puppet 4 updates and EPP template support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
 matrix:
   exclude:
     - rvm: 2.1.6
+      env: PUPPET_VERSION="~> 3.2.0"
+    - rvm: 2.1.6
       env: PUPPET_VERSION="~> 3.1.0"
     - rvm: 2.1.6
       env: PUPPET_VERSION="~> 3.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,20 @@ language: ruby
 script: bundle exec rake
 rvm:
   - 1.9.3
+  - 2.1.6
 env:
   - PUPPET_VERSION="~> 3.0.0"
   - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.7.3"
+  - PUPPET_VERSION="~> 4.2.0"
   - PUPPET_VERSION=">= 0"
 matrix:
+  exclude:
+    - rvm: 2.1.6
+      env: PUPPET_VERSION="~> 3.1.0"
+    - rvm: 2.1.6
+      env: PUPPET_VERSION="~> 3.0.0"
   allow_failures:
     - env: PUPPET_VERSION=">= 0"

--- a/lib/puppet-syntax.rb
+++ b/lib/puppet-syntax.rb
@@ -10,6 +10,6 @@ module PuppetSyntax
   @fail_on_deprecation_notices = true
 
   class << self
-    attr_accessor :exclude_paths, :future_parser, :hieradata_paths, :fail_on_deprecation_notices
+    attr_accessor :exclude_paths, :future_parser, :hieradata_paths, :fail_on_deprecation_notices, :epp_only
   end
 end

--- a/lib/puppet-syntax/manifests.rb
+++ b/lib/puppet-syntax/manifests.rb
@@ -53,7 +53,7 @@ module PuppetSyntax
 
     private
     def validate_manifest(file)
-      Puppet[:parser] = 'future' if PuppetSyntax.future_parser
+      Puppet[:parser] = 'future' if PuppetSyntax.future_parser and Puppet::PUPPETVERSION.to_i < 4
       Puppet::Face[:parser, :current].validate(file)
     end
   end

--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -30,6 +30,11 @@ to puppetlabs_spec_helper >= 0.8.0 which now uses puppet-syntax.
 
         desc 'Syntax check Puppet manifests'
         task :manifests do |t|
+          if Puppet::PUPPETVERSION.to_i >= 4 and PuppetSyntax.future_parser
+            info <<-EOS
+[INFO] Puppet 4 has been detected and `future_parser` has been set to
+'true'. The `future_parser setting will be ignored.
+            EOS
           $stderr.puts "---> #{t.name}"
           files = FileList["**/*.pp"]
           files.reject! { |f| File.directory?(f) }

--- a/lib/puppet-syntax/templates.rb
+++ b/lib/puppet-syntax/templates.rb
@@ -1,6 +1,6 @@
 require 'erb'
-require 'stringio'
 require 'puppet'
+require 'stringio'
 
 module PuppetSyntax
   class Templates

--- a/lib/puppet-syntax/templates.rb
+++ b/lib/puppet-syntax/templates.rb
@@ -27,7 +27,10 @@ module PuppetSyntax
     end
 
     def validate_epp(filename)
-      raise "Cannot validate EPP without Puppet 4" unless Puppet::PUPPETVERSION.to_i >= 4
+      if Puppet::PUPPETVERSION.to_i < 4
+        raise "Cannot validate EPP without Puppet 4"
+      end
+
       require 'puppet/pops'
       errors = []
       begin

--- a/lib/puppet-syntax/templates.rb
+++ b/lib/puppet-syntax/templates.rb
@@ -1,5 +1,6 @@
 require 'erb'
 require 'stringio'
+require 'puppet'
 
 module PuppetSyntax
   class Templates
@@ -10,25 +11,51 @@ module PuppetSyntax
       $stderr = warnings = StringIO.new()
       errors = []
 
-      filelist.each do |erb_file|
-        begin
-          erb = ERB.new(File.read(erb_file), nil, '-')
-          erb.filename = erb_file
-          erb.result
-        rescue NameError
-          # This is normal because we don't have the variables that would
-          # ordinarily be bound by the parent Puppet manifest.
-        rescue TypeError
-          # This is normal because we don't have the variables that would
-          # ordinarily be bound by the parent Puppet manifest.
-        rescue SyntaxError => error
-          errors << error
+      filelist.each do |file|
+        if File.extname(file) == '.epp' or PuppetSyntax.epp_only
+          errors.concat validate_epp(file)
+        else
+          errors.concat validate_erb(file)
         end
       end
 
       $stderr = STDERR
       errors << warnings.string unless warnings.string.empty?
       errors.map! { |e| e.to_s }
+
+      errors
+    end
+
+    def validate_epp(filename)
+      raise "Cannot validate EPP without Puppet 4" unless Puppet::PUPPETVERSION.to_i >= 4
+      require 'puppet/pops'
+      errors = []
+      begin
+        parser = Puppet::Pops::Parser::EvaluatingParser::EvaluatingEppParser.new()
+        parser.parse_file(filename)
+      rescue => detail
+        errors << detail
+      end
+
+      errors
+    end
+
+    def validate_erb(filename)
+      errors = []
+
+      begin
+        erb = ERB.new(File.read(filename), nil, '-')
+        erb.filename = filename
+        erb.result
+      rescue NameError => error
+        # This is normal because we don't have the variables that would
+        # ordinarily be bound by the parent Puppet manifest.
+      rescue TypeError
+        # This is normal because we don't have the variables that would
+        # ordinarily be bound by the parent Puppet manifest.
+      rescue SyntaxError => error
+        errors << error
+      end
 
       errors
     end

--- a/spec/fixtures/test_module/templates/fail_error.epp
+++ b/spec/fixtures/test_module/templates/fail_error.epp
@@ -1,0 +1,3 @@
+This is plain text
+<% This is not valid EPP %>
+This is also plain text

--- a/spec/fixtures/test_module/templates/fail_error_also.epp
+++ b/spec/fixtures/test_module/templates/fail_error_also.epp
@@ -1,0 +1,3 @@
+This is plain text
+<% } %>
+This is also plain text

--- a/spec/fixtures/test_module/templates/pass.epp
+++ b/spec/fixtures/test_module/templates/pass.epp
@@ -1,0 +1,3 @@
+<%# VALID COMMENT %>
+<% $valid = 'valid' -%>
+This is a <%= $valid %> template.

--- a/spec/fixtures/test_module/templates/pass_also.epp
+++ b/spec/fixtures/test_module/templates/pass_also.epp
@@ -1,0 +1,3 @@
+<%# VALID COMMENT %>
+<% $valid = 'valid' -%>
+This is a <%= $valid %> template.

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -157,15 +157,16 @@ describe PuppetSyntax::Manifests do
           expect(output[0]).to match(/Syntax error at '='; expected '\}' .*:2$/)
           expect(has_errors).to eq(true)
         end
-      end
-      it 'should succeed on Puppet >= 4.0.0' do
-        expect(PuppetSyntax.future_parser).to eq(false)
+      else
+        it 'should succeed on Puppet >= 4.0.0' do
+          expect(PuppetSyntax.future_parser).to eq(false)
 
-        files = fixture_manifests(['future_syntax.pp'])
-        output, has_errors = subject.check(files)
+          files = fixture_manifests(['future_syntax.pp'])
+          output, has_errors = subject.check(files)
 
-        expect(output.size).to eq(0)
-        expect(has_errors).to eq(false)
+          expect(output.size).to eq(0)
+          expect(has_errors).to eq(false)
+        end
       end
     end
 

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -46,13 +46,8 @@ describe PuppetSyntax::Manifests do
     expect(output.size).to eq(2)
     expect(has_errors).to eq(true)
 
-    if Puppet::PUPPETVERSION.to_i >= 4
-      expect(output[0]).to match(/Unrecognized escape sequence '\\\[' at \S*\/fail_warning.pp:3:51$/)
-      expect(output[1]).to match(/Unrecognized escape sequence '\\\]' .t \S*\/fail_warning.pp:3:51$/)
-    else
-      expect(output[0]).to match(/Unrecognised escape sequence '\\\[' .* at line 3$/)
-      expect(output[1]).to match(/Unrecognised escape sequence '\\\]' .* at line 3$/)
-    end
+    expect(output[0]).to match(/Unrecogni(s|z)ed escape sequence '\\\['/)
+    expect(output[1]).to match(/Unrecogni(s|z)ed escape sequence '\\\]'/)
   end
 
   it 'should ignore warnings about storeconfigs' do
@@ -82,13 +77,13 @@ describe PuppetSyntax::Manifests do
       expect(output[0]).to match(/This Name has no effect. A Host Class Definition can not end with a value-producing expression without other effect at \S*\/fail_error.pp:2:32$/)
       expect(output[1]).to match(/This Name has no effect. A value-producing expression without other effect may only be placed last in a block\/sequence at \S*\/fail_error.pp:2:3$/)
       expect(output[2]).to match('Found 2 errors. Giving up')
-      expect(output[3]).to match(/Unrecognized escape sequence '\\\[' at \S*\/fail_warning.pp:3:51$/)
-      expect(output[4]).to match(/Unrecognized escape sequence '\\\]' at \S*\/fail_warning.pp:3:51$/)
+      expect(output[3]).to match(/Unrecogni(s|z)ed escape sequence '\\\['/)
+      expect(output[4]).to match(/Unrecogni(s|z)ed escape sequence '\\\]'/)
     else
       expect(output.size).to eq(3)
       expect(output[0]).to match(/Syntax error at '\}' .*:3$/)
-      expect(output[1]).to match(/Unrecognised escape sequence '\\\[' .* at line 3$/)
-      expect(output[2]).to match(/Unrecognised escape sequence '\\\]' .* at line 3$/)
+      expect(output[1]).to match(/Unrecogni(s|z)ed escape sequence '\\\['/)
+      expect(output[2]).to match(/Unrecogni(s|z)ed escape sequence '\\\]'/)
     end
   end
 

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -89,6 +89,17 @@ describe PuppetSyntax::Manifests do
 
   describe 'deprecation notices' do
     case Puppet.version.to_f
+    when 4.0..4.99
+      context 'on puppet 4.0.0 and above' do
+        it 'should instead be failures' do
+          files = fixture_manifests('deprecation_notice.pp')
+          output, has_errors = subject.check(files)
+
+          expect(has_errors).to eq(true)
+          expect(output.size).to eq(1)
+          expect(output[0]).to match (/Node inheritance is not supported in Puppet >= 4.0.0/)
+        end
+      end
     when 3.7, 3.8
       context 'on puppet 3.7 and 3.8' do
         it 'should return deprecation notices as warnings' do
@@ -120,19 +131,6 @@ describe PuppetSyntax::Manifests do
 
           expect(output).to eq([])
           expect(has_errors).to eq(false)
-        end
-      end
-    end
-
-    if Puppet.version.to_i == 4
-      context 'on puppet 4.0.0 and above' do
-        it 'should instead be failures' do
-          files = fixture_manifests('deprecation_notice.pp')
-          output, has_errors = subject.check(files)
-
-          expect(has_errors).to eq(true)
-          expect(output.size).to eq(1)
-          expect(output[0]).to match (/Node inheritance is not supported in Puppet >= 4.0.0/)
         end
       end
     end

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -88,44 +88,43 @@ describe PuppetSyntax::Manifests do
   end
 
   describe 'deprecation notices' do
-    # These tests should fail in Puppet 4, but we need to wait for the release
-    # before we'll know exactly how to test it.
-    if Puppet::PUPPETVERSION.to_i < 4
-      if Puppet::Util::Package.versioncmp(Puppet.version, '3.7') >= 0
-        context 'on puppet >= 3.7' do
-          it 'should return deprecation notices as warnings' do
-            files = fixture_manifests('deprecation_notice.pp')
-            output, has_errors = subject.check(files)
+    case Puppet.version.to_f
+    when 3.7, 3.8
+      context 'on puppet 3.7 and 3.8' do
+        it 'should return deprecation notices as warnings' do
+          files = fixture_manifests('deprecation_notice.pp')
+          output, has_errors = subject.check(files)
 
-            expect(has_errors).to eq(false)
-            expect(output.size).to eq(2)
-            expect(output[0]).to match(/The use of 'import' is deprecated/)
-            expect(output[1]).to match(/Deprecation notice:/)
-          end
-        end
-      elsif Puppet::Util::Package.versioncmp(Puppet.version, '3.5') >= 0
-        context 'on puppet 3.5 and 3.6' do
-          it 'should return deprecation notices as warnings' do
-            files = fixture_manifests('deprecation_notice.pp')
-            output, has_errors = subject.check(files)
-
-            expect(has_errors).to eq(false)
-            expect(output.size).to eq(1)
-            expect(output[0]).to match(/The use of 'import' is deprecated/)
-          end
-        end
-      elsif Puppet::Util::Package.versioncmp(Puppet.version, '3.5') < 0
-        context 'on puppet < 3.5' do
-          it 'should not print deprecation notices' do
-            files = fixture_manifests('deprecation_notice.pp')
-            output, has_errors = subject.check(files)
-
-            expect(output).to eq([])
-            expect(has_errors).to eq(false)
-          end
+          expect(has_errors).to eq(false)
+          expect(output.size).to eq(2)
+          expect(output[0]).to match(/The use of 'import' is deprecated/)
+          expect(output[1]).to match(/Deprecation notice:/)
         end
       end
-    else
+    when 3.5, 3.6
+      context 'on puppet 3.5 and 3.6' do
+        it 'should return deprecation notices as warnings' do
+          files = fixture_manifests('deprecation_notice.pp')
+          output, has_errors = subject.check(files)
+
+          expect(has_errors).to eq(false)
+          expect(output.size).to eq(1)
+          expect(output[0]).to match(/The use of 'import' is deprecated/)
+        end
+      end
+    when 3.0..3.4
+      context 'on puppet 3.0 to 3.4' do
+        it 'should not print deprecation notices' do
+          files = fixture_manifests('deprecation_notice.pp')
+          output, has_errors = subject.check(files)
+
+          expect(output).to eq([])
+          expect(has_errors).to eq(false)
+        end
+      end
+    end
+
+    if Puppet.version.to_i == 4
       context 'on puppet 4.0.0 and above' do
         it 'should instead be failures' do
           files = fixture_manifests('deprecation_notice.pp')

--- a/spec/puppet-syntax/templates_spec.rb
+++ b/spec/puppet-syntax/templates_spec.rb
@@ -60,6 +60,15 @@ describe PuppetSyntax::Templates do
     expect(res).to match([])
   end
 
+  if Puppet::PUPPETVERSION.to_i < 4
+    context 'on Puppet < 4.0.0' do
+      it 'should fail when parsing EPP files' do
+        file = fixture_templates('pass.epp')
+        expect{ subject.check(file) }.to raise_error(/Cannot validate EPP without Puppet 4/)
+      end
+    end
+  end
+
   if Puppet::PUPPETVERSION.to_i >= 4
     context 'on Puppet >= 4.0.0' do
       it 'should return nothing from a valid file' do

--- a/spec/puppet-syntax/templates_spec.rb
+++ b/spec/puppet-syntax/templates_spec.rb
@@ -62,9 +62,20 @@ describe PuppetSyntax::Templates do
 
   if Puppet::PUPPETVERSION.to_i < 4
     context 'on Puppet < 4.0.0' do
-      it 'should fail when parsing EPP files' do
+      it 'should throw an exception when parsing EPP files' do
         file = fixture_templates('pass.epp')
         expect{ subject.check(file) }.to raise_error(/Cannot validate EPP without Puppet 4/)
+      end
+
+      context "when the 'epp_only' options is set" do
+        before(:each) {
+          PuppetSyntax.epp_only = true
+        }
+
+        it 'should throw an exception for any file' do
+          file = fixture_templates('pass.erb')
+          expect{ subject.check(file) }.to raise_error(/Cannot validate EPP without Puppet 4/)
+        end
       end
     end
   end
@@ -100,6 +111,19 @@ describe PuppetSyntax::Templates do
         expect(res.size).to eq(2)
         expect(res[0]).to match(/This Type-Name has no effect/)
         expect(res[1]).to match(/Syntax error at '}' at \S*\/fail_error_also.epp:2:4/)
+      end
+
+      context "when the 'epp_only' options is set" do
+        before(:each) {
+          PuppetSyntax.epp_only = true
+        }
+
+        it 'should process an ERB as EPP and find an error' do
+          files = fixture_templates('pass.erb')
+          res = subject.check(files)
+
+          expect(res.size).to eq(1)
+        end
       end
     end
   end

--- a/spec/puppet-syntax/templates_spec.rb
+++ b/spec/puppet-syntax/templates_spec.rb
@@ -59,4 +59,39 @@ describe PuppetSyntax::Templates do
 
     expect(res).to match([])
   end
+
+  if Puppet::PUPPETVERSION.to_i >= 4
+    context 'on Puppet >= 4.0.0' do
+      it 'should return nothing from a valid file' do
+        files = fixture_templates('pass.epp')
+        res = subject.check(files)
+
+        expect(res).to match([])
+      end
+
+      it 'should catch SyntaxError' do
+        files = fixture_templates('fail_error.epp')
+        res = subject.check(files)
+
+        expect(res.size).to eq(1)
+        expect(res[0]).to match(/This Type-Name has no effect/)
+      end
+
+      it 'should read more than one valid file' do
+        files = fixture_templates(['pass.epp', 'pass_also.epp'])
+        res = subject.check(files)
+
+        expect(res).to match([])
+      end
+
+      it 'should continue after finding an error in the first file' do
+        files = fixture_templates(['fail_error.epp', 'fail_error_also.epp'])
+        res = subject.check(files)
+
+        expect(res.size).to eq(2)
+        expect(res[0]).to match(/This Type-Name has no effect/)
+        expect(res[1]).to match(/Syntax error at '}' at \S*\/fail_error_also.epp:2:4/)
+      end
+    end
+  end
 end

--- a/spec/puppet-syntax_spec.rb
+++ b/spec/puppet-syntax_spec.rb
@@ -29,4 +29,9 @@ describe PuppetSyntax do
     expect(PuppetSyntax.fail_on_deprecation_notices).to eq(false)
   end
 
+  it 'should support forcing EPP only templates' do
+    PuppetSyntax.epp_only = true
+    expect(PuppetSyntax.epp_only).to eq(true)
+  end
+
 end


### PR DESCRIPTION
This PR has an overarching theme, Puppet 4 time! This PR contains commits that bring this project into working order with Puppet 4. For the most part the project was already there. Manifest validation in Puppet 4 worked just fine, but the unit tests needed to be updated. The only thing missing was EPP template support. That has been added too.