### PR TITLE
Update for puppet 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 language: ruby
+# Workaround https://github.com/bundler/bundler/issues/3558
+before_install: gem install bundler
 script: bundle exec rake
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.7.3"
   - PUPPET_VERSION="~> 4.2.0"
+  - PUPPET_VERSION="~> 4.3.0"
   - PUPPET_VERSION=">= 0"
 matrix:
   exclude:

--- a/lib/puppet-syntax/tasks/puppet-syntax.rb
+++ b/lib/puppet-syntax/tasks/puppet-syntax.rb
@@ -35,6 +35,7 @@ to puppetlabs_spec_helper >= 0.8.0 which now uses puppet-syntax.
 [INFO] Puppet 4 has been detected and `future_parser` has been set to
 'true'. The `future_parser setting will be ignored.
             EOS
+          end
           $stderr.puts "---> #{t.name}"
           files = FileList["**/*.pp"]
           files.reject! { |f| File.directory?(f) }

--- a/spec/puppet-syntax/manifests_spec.rb
+++ b/spec/puppet-syntax/manifests_spec.rb
@@ -75,7 +75,7 @@ describe PuppetSyntax::Manifests do
     if Puppet::PUPPETVERSION.to_i >= 4
       expect(output.size).to eq(5)
       expect(output[0]).to match(/This Name has no effect. A Host Class Definition can not end with a value-producing expression without other effect at \S*\/fail_error.pp:2:32$/)
-      expect(output[1]).to match(/This Name has no effect. A value-producing expression without other effect may only be placed last in a block\/sequence at \S*\/fail_error.pp:2:3$/)
+      expect(output[1]).to match(/This Name has no effect. A value(-producing expression without other effect may only be placed last in a block\/sequence| was produced and then forgotten.*) at \S*\/fail_error.pp:2:3$/)
       expect(output[2]).to match('Found 2 errors. Giving up')
       expect(output[3]).to match(/Unrecogni(s|z)ed escape sequence '\\\['/)
       expect(output[4]).to match(/Unrecogni(s|z)ed escape sequence '\\\]'/)

--- a/spec/puppet-syntax/tasks/puppet-syntax_spec.rb
+++ b/spec/puppet-syntax/tasks/puppet-syntax_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'puppet-syntax/tasks/puppet-syntax'
 
 describe 'PuppetSyntax rake tasks' do
   it 'should generate FileList of manifests relative to Rakefile' do


### PR DESCRIPTION
This adds 4.3 to the travis.yml and fixes a minor issue in tests when matching an error message.