### PR TITLE
Force a chdir back to our starting pwd after each template

### DIFF
--- a/lib/puppet-syntax/templates.rb
+++ b/lib/puppet-syntax/templates.rb
@@ -11,10 +11,13 @@ module PuppetSyntax
       $stderr = warnings = StringIO.new()
       errors = []
 
+      initial_directory = Dir.pwd
+
       filelist.each do |file|
         if File.extname(file) == '.epp' or PuppetSyntax.epp_only
           errors.concat validate_epp(file)
         else
+          Dir.chdir(initial_directory)
           errors.concat validate_erb(file)
         end
       end


### PR DESCRIPTION
In Issue #47 the issue of a template executing a chdir causing all future templates
in the puppet-syntax run to fail with 'Errno::ENOENT: No such file or directory'
was raised. We've managed to reproduce this on the command line, and fix it with
the included code, but we can only reproduce it very occasionally under rspec so
I'm submitting this as a PR without a test case.