### PR TITLE
Update puppet4 check to work on future parser implementations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ gemspec
 # Override gemspec for CI matrix builds.
 puppet_version = ENV['PUPPET_VERSION'] || '>2.7.0'
 gem 'puppet', puppet_version
+
+# older version required for ruby 1.9 compat, as it is pulled in as dependency of puppet, this has to be carried by the module
+gem 'json_pure', '<= 2.0.1'

--- a/lib/puppet-syntax/templates.rb
+++ b/lib/puppet-syntax/templates.rb
@@ -27,8 +27,8 @@ module PuppetSyntax
     end
 
     def validate_epp(filename)
-      if Puppet::PUPPETVERSION.to_i < 4
-        raise "Cannot validate EPP without Puppet 4"
+      if Puppet::PUPPETVERSION.to_f < 3.7
+        raise "Cannot validate EPP without Puppet 4 or future parser (3.7+)"
       end
 
       require 'puppet/pops'

--- a/spec/puppet-syntax/templates_spec.rb
+++ b/spec/puppet-syntax/templates_spec.rb
@@ -60,8 +60,8 @@ describe PuppetSyntax::Templates do
     expect(res).to match([])
   end
 
-  if Puppet::PUPPETVERSION.to_i < 4
-    context 'on Puppet < 4.0.0' do
+  if Puppet::PUPPETVERSION.to_f < 3.7
+    context 'on Puppet < 3.7' do
       it 'should throw an exception when parsing EPP files' do
         file = fixture_templates('pass.epp')
         expect{ subject.check(file) }.to raise_error(/Cannot validate EPP without Puppet 4/)
@@ -80,8 +80,8 @@ describe PuppetSyntax::Templates do
     end
   end
 
-  if Puppet::PUPPETVERSION.to_i >= 4
-    context 'on Puppet >= 4.0.0' do
+  if Puppet::PUPPETVERSION.to_f >= 3.7
+    context 'on Puppet >= 3.7' do
       it 'should return nothing from a valid file' do
         files = fixture_templates('pass.epp')
         res = subject.check(files)


### PR DESCRIPTION
The last versions of puppet 3 provide already enough infrastructure to validate
epp. If that infrastructure is available, use it.