### PR TITLE
Update gem author to be Government Digital Service

### DIFF
--- a/puppet-syntax.gemspec
+++ b/puppet-syntax.gemspec
@@ -6,8 +6,7 @@ require 'puppet-syntax/version'
 Gem::Specification.new do |spec|
   spec.name          = "puppet-syntax"
   spec.version       = PuppetSyntax::VERSION
-  spec.authors       = ["Dan Carley"]
-  spec.email         = ["dan.carley@gmail.com"]
+  spec.authors       = ["Government Digital Service"]
   spec.description   = %q{Syntax checks for Puppet manifests and templates}
   spec.summary       = %q{Syntax checks for Puppet manifests, templates, and Hiera YAML}
   spec.homepage      = "https://github.com/gds-operations/puppet-syntax"


### PR DESCRIPTION
I believe that gems under the [govuk rubygems account](https://rubygems.org/profiles/govuk) should have no individual authors but mention `Government Digital Service` as a whole.

We are a team and most of us contribute to several gems but never got to add themselves as an author. By setting this as `Government Digital Service` it's self implied that anyone that contributed is contributing for the `Government Digital Service` as a team.

My other proposal would be to follow [Slimmer](https://github.com/alphagov/slimmer/blob/master/slimmer.gemspec#L11-L12) instead